### PR TITLE
Feat: make login maintenence logic

### DIFF
--- a/app/src/main/java/com/example/bangwool/SplashActivity.kt
+++ b/app/src/main/java/com/example/bangwool/SplashActivity.kt
@@ -5,7 +5,19 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.widget.Toast
+import com.example.bangwool.retrofit.AuthLoginRequest
+import com.example.bangwool.retrofit.RetrofitUtil
+import com.example.bangwool.retrofit.TokenResponse
+import com.example.bangwool.retrofit.getPassword
+import com.example.bangwool.retrofit.getUserId
+import com.example.bangwool.retrofit.removePassword
+import com.example.bangwool.retrofit.removeUserId
+import com.example.bangwool.retrofit.saveAccessToken
 import com.example.bangwool.ui.login.LoginActivity
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
 
 class SplashActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -13,9 +25,46 @@ class SplashActivity : AppCompatActivity() {
         val handler = Handler();
         Handler(Looper.getMainLooper()).postDelayed({
 //            val i = Intent(this, LoginActivity::class.java)
-            val i = Intent(this, LoginActivity::class.java)
-            startActivity(i)
-            finish()
+            val userId = getUserId(this)
+            val password = getPassword(this)
+            if(!(userId.equals("0"))&&!(password.equals("0"))){
+                val authLoginRequest = AuthLoginRequest(userId, password)
+                RetrofitUtil.getLoginRetrofit().AuthLogin(authLoginRequest).enqueue(object :
+                    Callback<TokenResponse> {
+                    override fun onResponse(
+                        call: Call<TokenResponse>,
+                        response: Response<TokenResponse>
+                    ) {
+                        if (response.isSuccessful) {
+                            val token = response.body()!!.token
+                            saveAccessToken(this@SplashActivity, token)
+                            RetrofitUtil.setAccessToken(token)
+                            val i = Intent(this@SplashActivity, MainActivity::class.java)
+                            i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)//이미 있는거 수정
+                            startActivity(i)
+                            Toast.makeText(this@SplashActivity, "로그인 성공", Toast.LENGTH_SHORT).show()
+                            finish()
+                            if (LoginActivity.activity != null)
+                                LoginActivity.activity!!.finish()
+                        } else {
+                            removeUserId(this@SplashActivity)
+                            removePassword(this@SplashActivity)
+                            val i = Intent(this@SplashActivity, LoginActivity::class.java)
+                            startActivity(i)
+                            finish()
+                        }
+                    }
+
+                    override fun onFailure(call: Call<TokenResponse>, t: Throwable) {
+
+                    }
+
+                })
+            } else {
+                val i = Intent(this, LoginActivity::class.java)
+                startActivity(i)
+                finish()
+            }
         }, 2000)
     }
 }

--- a/app/src/main/java/com/example/bangwool/retrofit/sharedPrefrences.kt
+++ b/app/src/main/java/com/example/bangwool/retrofit/sharedPrefrences.kt
@@ -42,3 +42,39 @@ fun removeGoalTime(context: Context) {
     edit.remove("goalTime")
     edit.apply()
 }
+
+fun saveUserId(context: Context, userId: String) {
+    val pref =
+        context.getSharedPreferences("userId_spf", Context.MODE_PRIVATE) //shared key 설정
+    val edit = pref.edit() // 수정모드
+    edit.putString("userId", userId) // 값 넣기
+    edit.apply() // 적용하기
+}
+fun getUserId(context: Context): String {
+    val spf = context.getSharedPreferences("userId_spf", AppCompatActivity.MODE_PRIVATE)
+    return spf.getString("userId", 0.toString())!!
+}
+
+fun savePassword(context: Context, password: String) {
+    val pref =
+        context.getSharedPreferences("password_spf", Context.MODE_PRIVATE) //shared key 설정
+    val edit = pref.edit() // 수정모드
+    edit.putString("password", password) // 값 넣기
+    edit.apply() // 적용하기
+}
+fun getPassword(context: Context): String {
+    val spf = context.getSharedPreferences("password_spf", AppCompatActivity.MODE_PRIVATE)
+    return spf.getString("password", 0.toString())!!
+}
+fun removeUserId(context: Context) {
+    val pref = context.getSharedPreferences("userId_spf", AppCompatActivity.MODE_PRIVATE)
+    val edit = pref.edit() // 수정모드
+    edit.remove("userId")
+    edit.apply()
+}
+fun removePassword(context: Context) {
+    val pref = context.getSharedPreferences("password_spf", AppCompatActivity.MODE_PRIVATE)
+    val edit = pref.edit() // 수정모드
+    edit.remove("password")
+    edit.apply()
+}

--- a/app/src/main/java/com/example/bangwool/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/example/bangwool/ui/login/LoginActivity.kt
@@ -21,11 +21,19 @@ import androidx.core.content.ContextCompat
 import com.example.bangwool.MainActivity
 import com.example.bangwool.R
 import com.example.bangwool.databinding.ActivityLoginBinding
+import com.example.bangwool.retrofit.AuthLoginRequest
 import com.example.bangwool.retrofit.ExistResponse
 import com.example.bangwool.retrofit.KakaoLoginRequest
 import com.example.bangwool.retrofit.OAuthTokenResponse
 import com.example.bangwool.retrofit.RetrofitUtil
+import com.example.bangwool.retrofit.TokenResponse
+import com.example.bangwool.retrofit.getPassword
+import com.example.bangwool.retrofit.getUserId
+import com.example.bangwool.retrofit.removePassword
+import com.example.bangwool.retrofit.removeUserId
 import com.example.bangwool.retrofit.saveAccessToken
+import com.example.bangwool.retrofit.savePassword
+import com.example.bangwool.retrofit.saveUserId
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
@@ -47,6 +55,39 @@ class LoginActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityLoginBinding.inflate(layoutInflater)
         setContentView(binding.root)
+//        val userId = getUserId(this)
+//        val password = getPassword(this)
+//        if(!(userId.equals("0"))&&!(password.equals("0"))){
+//            val authLoginRequest = AuthLoginRequest(userId, password)
+//            RetrofitUtil.getLoginRetrofit().AuthLogin(authLoginRequest).enqueue(object :
+//                Callback<TokenResponse> {
+//                override fun onResponse(
+//                    call: Call<TokenResponse>,
+//                    response: Response<TokenResponse>
+//                ) {
+//                    if (response.isSuccessful) {
+//                        val token = response.body()!!.token
+//                        saveAccessToken(this@LoginActivity, token)
+//                        RetrofitUtil.setAccessToken(token)
+//                        val i = Intent(this@LoginActivity, MainActivity::class.java)
+//                        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)//이미 있는거 수정
+//                        startActivity(i)
+//                        Toast.makeText(this@LoginActivity, "로그인 성공", Toast.LENGTH_SHORT).show()
+//                        finish()
+//                        if (LoginActivity.activity != null)
+//                            LoginActivity.activity!!.finish()
+//                    } else {
+//                        removeUserId(this@LoginActivity)
+//                        removePassword(this@LoginActivity)
+//                    }
+//                }
+//
+//                override fun onFailure(call: Call<TokenResponse>, t: Throwable) {
+//
+//                }
+//
+//            })
+//        }
         co.activity = this
 
         init()

--- a/app/src/main/java/com/example/bangwool/ui/login/PasswordActivity.kt
+++ b/app/src/main/java/com/example/bangwool/ui/login/PasswordActivity.kt
@@ -14,6 +14,8 @@ import com.example.bangwool.retrofit.AuthLoginRequest
 import com.example.bangwool.retrofit.RetrofitUtil
 import com.example.bangwool.retrofit.TokenResponse
 import com.example.bangwool.retrofit.saveAccessToken
+import com.example.bangwool.retrofit.savePassword
+import com.example.bangwool.retrofit.saveUserId
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -107,7 +109,8 @@ class PasswordActivity : AppCompatActivity() {
                     val token = response.body()!!.token
                     saveAccessToken(this@PasswordActivity, token)
                     RetrofitUtil.setAccessToken(token)
-
+                    saveUserId(this@PasswordActivity,userId!!)
+                    savePassword(this@PasswordActivity,passwordEt.text.toString())
                     pwTextInputLayout.error = null
                     pwTextInputLayout.isErrorEnabled = false
                     loginIcErrorEmail.visibility = View.GONE

--- a/app/src/main/java/com/example/bangwool/ui/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/example/bangwool/ui/mypage/MyPageFragment.kt
@@ -7,6 +7,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.example.bangwool.databinding.FragmentMypageBinding
+import com.example.bangwool.retrofit.removePassword
+import com.example.bangwool.retrofit.removeUserId
 import com.example.bangwool.ui.login.LoginActivity
 
 class MyPageFragment : Fragment() {
@@ -23,6 +25,8 @@ class MyPageFragment : Fragment() {
         // 로그아웃 버튼 클릭 이벤트
         binding.textViewLogout.setOnClickListener {
             // 로그아웃 버튼을 클릭하면 LoginActivity로 이동하고 현재 액티비티를 종료
+            removeUserId(requireContext())
+            removePassword(requireContext())
             val intent = Intent(activity, LoginActivity::class.java)
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
             startActivity(intent)


### PR DESCRIPTION
# 개요
###### PR에 관한 개략적인 설명을 써주세요

로그인 유지 기능 추가

# 수정사항
###### 작업 내용을 써주세요

로그인한 이후 로그아웃을 하지않고 나갔을 시, 로컬에 아이디와 비밀번호를 저장하여 다시 앱에 들어왔을때, 자동적으로 스플래쉬 화면에서 로컬에 아이디와 비밀번호 정보가 있는지 확인후 존재한다면 로그인하여 바로 메인 액티비티로 이동

마이페이지 프래그먼트에서 로그아웃 버튼을 눌렀을때 로컬에서 아이디와 비밀번호 로컬 데이터가 지워지도록 설정

# 유의사항
###### 리뷰 시 참고할 내용을 써주세요

코드는 sharedprefrence, splashActivity, mypageFragment에 추가했습니다. 확인해주세요
그리고 로그인 유지 방법중 더 좋은 방법이 있으면 의견 적극적으로 내주세요.
사실 로컬에 아이디와 비밀번호를 저장하는건 임시적으로 하는 조금 보안이 취약한 방법이기때문에 나중에 수정할수있으면 바로 수정하겠습니다.