### PR TITLE
Fix: fix problem weekStatisticTable's height keep higher

### DIFF
--- a/app/src/main/java/com/example/bangwool/ui/statistic/StatisticFragment.kt
+++ b/app/src/main/java/com/example/bangwool/ui/statistic/StatisticFragment.kt
@@ -332,7 +332,7 @@ class StatisticFragment : Fragment() {
                 240F,
                 resources.displayMetrics
             ).toInt()
-            lp.height = lp.height+viewHeight
+            lp.height = viewHeight
             binding.llStudyTimesTable.layoutParams = lp
 
         } else {


### PR DESCRIPTION
# 개요
###### PR에 관한 개략적인 설명을 써주세요

주간 통계 그래프 높이가 목표시간을 변경할때마다 길어지는 버그 수정

# 수정사항
###### 작업 내용을 써주세요

주간 통계 그래프의 max hour가 0일때 그래프의 높이를 설정하는 로직을 기존 높이에서 240dp씩 더하는 방식에서 240dp로 유지되게 수정

# 유의사항
###### 리뷰 시 참고할 내용을 써주세요
