### PR TITLE
Bw 137 android make edit privacy activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,12 +17,17 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
+            android:name=".ui.mypage.EditPrivacyActivity"
+            android:exported="false" />
+        <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+
                 <data
                     android:host="oauth"
                     android:scheme="${KAKAO_KEY}" />
@@ -34,6 +39,7 @@
             android:theme="@style/Theme.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
@@ -46,23 +52,19 @@
         <activity
             android:name=".ui.login.FindPasswordActivity"
             android:exported="false" />
-
         <activity android:name=".ui.login.RegisterActivity" />
         <activity android:name=".ui.login.PrivacyPolicyActivity" />
         <activity android:name=".ui.login.TermsAgreeActivity" />
         <activity android:name=".ui.login.UsePolicyActivity" />
->
         <activity
             android:name=".MainActivity"
             android:exported="false" />
-
         <activity
             android:name=".ui.home.TimerActivity"
             android:exported="false" />
         <activity
             android:name=".ui.home.TimerEditActivity"
             android:exported="false" />
-
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/bangwool/ui/mypage/EditPrivacyActivity.kt
+++ b/app/src/main/java/com/example/bangwool/ui/mypage/EditPrivacyActivity.kt
@@ -2,6 +2,7 @@ package com.example.bangwool.ui.mypage
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.view.View
 import com.example.bangwool.R
 import com.example.bangwool.databinding.ActivityEditPrivacyBinding
 import com.example.bangwool.databinding.ActivityTimerBinding
@@ -14,6 +15,19 @@ class EditPrivacyActivity : AppCompatActivity() {
         binding.icBack.setOnClickListener{
             finish()
         }
+        val nickname = intent.getStringExtra("nickname")
+        val profileImage = intent.getStringExtra("profileImage")
+        val email = intent.getStringExtra("email")
+        binding.tvNickname.text = nickname
+        binding.tvEmail.text = email
+
+        binding.btnEditPasswordBefore.setOnClickListener{
+            binding.btnEditPasswordBefore.visibility = View.GONE
+            binding.clPassword.visibility = View.VISIBLE
+            binding.clCheckPassword.visibility = View.VISIBLE
+            binding.btnEditPasswordAfter.visibility = View.VISIBLE
+        }
+
         setContentView(binding.root)
     }
 }

--- a/app/src/main/java/com/example/bangwool/ui/mypage/EditPrivacyActivity.kt
+++ b/app/src/main/java/com/example/bangwool/ui/mypage/EditPrivacyActivity.kt
@@ -3,10 +3,17 @@ package com.example.bangwool.ui.mypage
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import com.example.bangwool.R
+import com.example.bangwool.databinding.ActivityEditPrivacyBinding
+import com.example.bangwool.databinding.ActivityTimerBinding
 
 class EditPrivacyActivity : AppCompatActivity() {
+    lateinit var binding: ActivityEditPrivacyBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_edit_privacy)
+        binding = ActivityEditPrivacyBinding.inflate(layoutInflater)
+        binding.icBack.setOnClickListener{
+            finish()
+        }
+        setContentView(binding.root)
     }
 }

--- a/app/src/main/java/com/example/bangwool/ui/mypage/EditPrivacyActivity.kt
+++ b/app/src/main/java/com/example/bangwool/ui/mypage/EditPrivacyActivity.kt
@@ -26,6 +26,7 @@ class EditPrivacyActivity : AppCompatActivity() {
             binding.clPassword.visibility = View.VISIBLE
             binding.clCheckPassword.visibility = View.VISIBLE
             binding.btnEditPasswordAfter.visibility = View.VISIBLE
+            binding.svMyInfo.isScrollbarFadingEnabled = false
         }
 
         setContentView(binding.root)

--- a/app/src/main/java/com/example/bangwool/ui/mypage/EditPrivacyActivity.kt
+++ b/app/src/main/java/com/example/bangwool/ui/mypage/EditPrivacyActivity.kt
@@ -1,0 +1,12 @@
+package com.example.bangwool.ui.mypage
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import com.example.bangwool.R
+
+class EditPrivacyActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_edit_privacy)
+    }
+}

--- a/app/src/main/java/com/example/bangwool/ui/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/example/bangwool/ui/mypage/MyPageFragment.kt
@@ -29,6 +29,9 @@ class MyPageFragment : Fragment() {
 
     lateinit var binding: FragmentMypageBinding
     private lateinit var retrofitInterface: RetrofitInterface
+    lateinit var nickname: String
+    lateinit var profileImage: String
+    lateinit var email: String
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -73,6 +76,9 @@ class MyPageFragment : Fragment() {
         }
         binding.myinfo.setOnClickListener {
             val i = Intent(requireContext(), EditPrivacyActivity::class.java)
+            i.putExtra("nickname", nickname)
+            i.putExtra("profileImage", profileImage)
+            i.putExtra("email", email)
             startActivity(i)
         }
     }
@@ -82,8 +88,9 @@ class MyPageFragment : Fragment() {
             override fun onResponse(call: Call<MyPageResponse>, response: Response<MyPageResponse>) {
                 if (response.isSuccessful) {
                     val myPageResponse = response.body()!!
-                    val nickname = myPageResponse.nickname
-                    val profileImage = myPageResponse.profileImage
+                    nickname = myPageResponse.nickname
+                    profileImage = myPageResponse.profileImage
+                    email = myPageResponse.email
 
 
                     // 닉네임 업데이트 부분

--- a/app/src/main/java/com/example/bangwool/ui/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/example/bangwool/ui/mypage/MyPageFragment.kt
@@ -19,6 +19,7 @@ import com.example.bangwool.retrofit.MyPageResponse
 import com.example.bangwool.retrofit.RetrofitInterface
 import com.example.bangwool.retrofit.RetrofitUtil
 import com.example.bangwool.retrofit.removeAccessToken
+import com.example.bangwool.ui.home.TimerEditActivity
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -69,6 +70,10 @@ class MyPageFragment : Fragment() {
         }
         binding.appinfoMenu.setOnClickListener {
             UpdateDialogUtils.showUpdateDialog(requireContext())
+        }
+        binding.myinfo.setOnClickListener {
+            val i = Intent(requireContext(), EditPrivacyActivity::class.java)
+            startActivity(i)
         }
     }
 

--- a/app/src/main/res/layout/activity_edit_privacy.xml
+++ b/app/src/main/res/layout/activity_edit_privacy.xml
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_top"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="20dp"
+        android:paddingTop="16dp"
+        android:paddingBottom="20dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/ic_timer_edit_back"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_back"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="@color/gray_800" />
+
+        <TextView
+            android:id="@+id/tv_timer_edit_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/p_medium"
+            android:text="내 정보"
+            android:textAlignment="center"
+            android:textColor="@color/gray_800"
+            android:textSize="@dimen/text_size_body3"
+            app:layout_constraintBottom_toBottomOf="@id/ic_timer_edit_back"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/ic_timer_edit_back" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+    
+    <View
+        android:id="@+id/line"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/gray_300"
+        app:layout_constraintBottom_toBottomOf="@id/cl_top"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_timer_name_input"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="24dp"
+        android:layout_marginTop="22dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/cl_top">
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_profile_picture"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+            <TextView
+                android:id="@+id/tv_profile_picture_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/p_medium"
+                android:text="프로필 사진"
+                android:textColor="@color/gray_700"
+                android:textSize="@dimen/text_size_body4"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+            <androidx.cardview.widget.CardView
+                android:id="@+id/cv_profile_picture"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/profile_border"
+                app:cardCornerRadius="32dp"
+                app:cardElevation="0dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_profile_picture_title">
+                <ImageView
+                    android:id="@+id/iv_profile_picture"
+                    android:layout_width="64dp"
+                    android:layout_height="64dp"
+                    android:src="@drawable/happy_tomato" />
+            </androidx.cardview.widget.CardView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_email"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/cl_profile_picture">
+            <TextView
+                android:id="@+id/tv_email_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/p_medium"
+                android:text="이메일"
+                android:textColor="@color/gray_700"
+                android:textSize="@dimen/text_size_body4"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+            <TextView
+                android:id="@+id/tv_email"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/p_medium"
+                android:text="banwol@google.com"
+                android:textColor="@color/gray_400"
+                android:layout_marginLeft="4dp"
+                android:paddingVertical="16dp"
+                android:textSize="@dimen/text_size_body4"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_email_title" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/cl_email">
+            <TextView
+                android:id="@+id/tv_name_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/p_medium"
+                android:text="이름"
+                android:textColor="@color/gray_700"
+                android:textSize="@dimen/text_size_body4"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+            <TextView
+                android:id="@+id/tv_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/p_medium"
+                android:text="방울즈"
+                android:textColor="@color/gray_400"
+                android:layout_marginLeft="4dp"
+                android:paddingVertical="16dp"
+                android:textSize="@dimen/text_size_body4"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_name_title" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_nickname"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/cl_name">
+            <TextView
+                android:id="@+id/tv_nickname_title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/p_medium"
+                android:text="닉네임"
+                android:textColor="@color/gray_700"
+                android:textSize="@dimen/text_size_body4"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+            <TextView
+                android:id="@+id/tv_nickname"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/p_medium"
+                android:text="방울이"
+                android:textColor="@color/gray_400"
+                android:layout_marginLeft="4dp"
+                android:paddingVertical="16dp"
+                android:textSize="@dimen/text_size_body4"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tv_nickname_title" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+    <android.widget.Button
+        android:id="@+id/btn_save"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="22dp"
+        android:layout_marginBottom="24dp"
+        android:background="@drawable/long_normal_btn"
+        android:fontFamily="@font/pretendard_semibold"
+        android:stateListAnimator="@null"
+        android:text="비밀번호 수정하기"
+        android:textColor="@color/gray_600"
+        android:backgroundTint="@color/gray_100"
+        android:textSize="@dimen/text_size_body4"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_edit_privacy.xml
+++ b/app/src/main/res/layout/activity_edit_privacy.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -51,23 +50,25 @@
         app:layout_constraintStart_toStartOf="parent" />
 
     <ScrollView
+        android:id="@+id/sv_my_info"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:fillViewport="true"
-        android:layout_marginTop="22dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/cl_top"
-        app:layout_constraintBottom_toBottomOf="parent">
+        app:layout_constraintTop_toBottomOf="@id/line">
+
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/cl_timer_name_input"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            >
+            android:layout_height="wrap_content">
+
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/cl_profile_picture"
-                android:layout_width="369dp"
+                android:layout_width="match_parent"
                 android:layout_height="96dp"
                 android:layout_marginHorizontal="24dp"
+                android:layout_marginTop="22dp"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent">
 
@@ -86,7 +87,7 @@
                     android:id="@+id/cv_profile_picture"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:background="@drawable/profile_border"
+                    android:background="@color/black"
                     app:cardCornerRadius="32dp"
                     app:cardElevation="0dp"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -100,6 +101,7 @@
                         android:src="@drawable/happy_tomato" />
                 </androidx.cardview.widget.CardView>
             </androidx.constraintlayout.widget.ConstraintLayout>
+
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/cl_email"
                 android:layout_width="match_parent"
@@ -108,6 +110,7 @@
                 android:layout_marginTop="24dp"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/cl_profile_picture">
+
                 <TextView
                     android:id="@+id/tv_email_title"
                     android:layout_width="wrap_content"
@@ -118,19 +121,21 @@
                     android:textSize="@dimen/text_size_body4"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
+
                 <TextView
                     android:id="@+id/tv_email"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginLeft="4dp"
                     android:fontFamily="@font/p_medium"
+                    android:paddingVertical="16dp"
                     android:text="banwol@google.com"
                     android:textColor="@color/gray_400"
-                    android:layout_marginLeft="4dp"
-                    android:paddingVertical="16dp"
                     android:textSize="@dimen/text_size_body4"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_email_title" />
             </androidx.constraintlayout.widget.ConstraintLayout>
+
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/cl_name"
                 android:layout_width="match_parent"
@@ -139,6 +144,7 @@
                 android:layout_marginTop="24dp"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/cl_email">
+
                 <TextView
                     android:id="@+id/tv_name_title"
                     android:layout_width="wrap_content"
@@ -149,19 +155,21 @@
                     android:textSize="@dimen/text_size_body4"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
+
                 <TextView
                     android:id="@+id/tv_name"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginLeft="4dp"
                     android:fontFamily="@font/p_medium"
+                    android:paddingVertical="16dp"
                     android:text="방울즈"
                     android:textColor="@color/gray_400"
-                    android:layout_marginLeft="4dp"
-                    android:paddingVertical="16dp"
                     android:textSize="@dimen/text_size_body4"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_name_title" />
             </androidx.constraintlayout.widget.ConstraintLayout>
+
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/cl_nickname"
                 android:layout_width="match_parent"
@@ -170,6 +178,7 @@
                 android:layout_marginTop="24dp"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/cl_name">
+
                 <TextView
                     android:id="@+id/tv_nickname_title"
                     android:layout_width="wrap_content"
@@ -180,28 +189,31 @@
                     android:textSize="@dimen/text_size_body4"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
+
                 <TextView
                     android:id="@+id/tv_nickname"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginLeft="4dp"
                     android:fontFamily="@font/p_medium"
+                    android:paddingVertical="16dp"
                     android:text="방울이"
                     android:textColor="@color/gray_400"
-                    android:layout_marginLeft="4dp"
-                    android:paddingVertical="16dp"
                     android:textSize="@dimen/text_size_body4"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_nickname_title" />
             </androidx.constraintlayout.widget.ConstraintLayout>
+
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/cl_password"
                 android:layout_width="match_parent"
-                android:visibility="gone"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="24dp"
                 android:layout_marginTop="24dp"
+                android:visibility="gone"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/cl_nickname">
+
                 <TextView
                     android:id="@+id/tv_password_title"
                     android:layout_width="wrap_content"
@@ -212,6 +224,7 @@
                     android:textSize="@dimen/text_size_body4"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
+
                 <com.google.android.material.textfield.TextInputLayout
                     android:id="@+id/textInputLayoutPassword"
                     android:layout_width="match_parent"
@@ -231,9 +244,9 @@
                         android:layout_height="wrap_content"
                         android:background="@null"
                         android:hint="8~12자, 영문대소문자, 숫자, 특수문자 포함"
+                        android:imeOptions="actionNext"
                         android:inputType="textPassword"
                         android:paddingStart="4dp"
-                        android:imeOptions="actionNext"
                         android:textColor="@color/gray_700"
                         android:textColorHint="@color/gray_400"
                         android:textSize="@dimen/text_size_body4"
@@ -251,15 +264,17 @@
                     app:layout_constraintTop_toBottomOf="@id/textInputLayoutPassword"
                     app:tint="@color/secondary" />
             </androidx.constraintlayout.widget.ConstraintLayout>
+
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:id="@+id/cl_check_password"
                 android:layout_width="match_parent"
-                android:layout_marginHorizontal="24dp"
                 android:layout_height="wrap_content"
-                android:visibility="gone"
+                android:layout_marginHorizontal="24dp"
                 android:layout_marginTop="24dp"
+                android:visibility="gone"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/cl_password">
+
                 <TextView
                     android:id="@+id/tv_check_password_title"
                     android:layout_width="wrap_content"
@@ -291,9 +306,9 @@
                         android:layout_height="wrap_content"
                         android:background="@null"
                         android:hint=" 패스워드를 확인해주세요"
+                        android:imeOptions="actionDone"
                         android:inputType="textPassword"
                         android:paddingStart="4dp"
-                        android:imeOptions="actionDone"
                         android:textColor="@color/gray_700"
                         android:textColorHint="@color/gray_400"
                         android:textSize="@dimen/text_size_body4"
@@ -312,6 +327,7 @@
                     app:tint="@color/secondary" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
+
             <android.widget.Button
                 android:id="@+id/btn_edit_password_after"
                 android:layout_width="match_parent"
@@ -319,18 +335,18 @@
                 android:layout_marginHorizontal="22dp"
                 android:layout_marginTop="45dp"
                 android:layout_marginBottom="24dp"
-                android:visibility="gone"
                 android:background="@drawable/long_normal_btn"
+                android:backgroundTint="@color/primary_300"
                 android:fontFamily="@font/pretendard_semibold"
                 android:stateListAnimator="@null"
                 android:text="비밀번호 수정하기"
                 android:textColor="@color/gray_0"
-                android:backgroundTint="@color/primary_300"
                 android:textSize="@dimen/text_size_body4"
-                app:layout_constraintTop_toBottomOf="@id/cl_check_password"
+                android:visibility="gone"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/cl_check_password" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </ScrollView>
@@ -343,17 +359,16 @@
         android:layout_marginHorizontal="22dp"
         android:layout_marginBottom="24dp"
         android:background="@drawable/long_normal_btn"
+        android:backgroundTint="@color/gray_100"
         android:fontFamily="@font/pretendard_semibold"
-        android:visibility="visible"
         android:stateListAnimator="@null"
         android:text="비밀번호 수정하기"
         android:textColor="@color/gray_600"
-        android:backgroundTint="@color/gray_100"
         android:textSize="@dimen/text_size_body4"
+        android:visibility="visible"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
-
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_edit_privacy.xml
+++ b/app/src/main/res/layout/activity_edit_privacy.xml
@@ -16,7 +16,7 @@
         app:layout_constraintTop_toTopOf="parent">
 
         <ImageView
-            android:id="@+id/ic_timer_edit_back"
+            android:id="@+id/ic_back"
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:src="@drawable/ic_back"
@@ -39,7 +39,7 @@
             app:layout_constraintTop_toTopOf="@id/ic_timer_edit_back" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-    
+
     <View
         android:id="@+id/line"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_edit_privacy.xml
+++ b/app/src/main/res/layout/activity_edit_privacy.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -33,10 +34,10 @@
             android:textAlignment="center"
             android:textColor="@color/gray_800"
             android:textSize="@dimen/text_size_body3"
-            app:layout_constraintBottom_toBottomOf="@id/ic_timer_edit_back"
+            app:layout_constraintBottom_toBottomOf="@id/ic_back"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/ic_timer_edit_back" />
+            app:layout_constraintTop_toTopOf="@id/ic_back" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -49,148 +50,301 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/cl_timer_name_input"
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="24dp"
+        android:layout_height="0dp"
+        android:fillViewport="true"
         android:layout_marginTop="22dp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/cl_top">
+        app:layout_constraintTop_toBottomOf="@id/cl_top"
+        app:layout_constraintBottom_toBottomOf="parent">
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/cl_profile_picture"
+            android:id="@+id/cl_timer_name_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
-            <TextView
-                android:id="@+id/tv_profile_picture_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/p_medium"
-                android:text="프로필 사진"
-                android:textColor="@color/gray_700"
-                android:textSize="@dimen/text_size_body4"
+            >
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_profile_picture"
+                android:layout_width="369dp"
+                android:layout_height="96dp"
+                android:layout_marginHorizontal="24dp"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-            <androidx.cardview.widget.CardView
-                android:id="@+id/cv_profile_picture"
-                android:layout_width="wrap_content"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <TextView
+                    android:id="@+id/tv_profile_picture_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/p_medium"
+                    android:text="프로필 사진"
+                    android:textColor="@color/gray_700"
+                    android:textSize="@dimen/text_size_body4"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/cv_profile_picture"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/profile_border"
+                    app:cardCornerRadius="32dp"
+                    app:cardElevation="0dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_profile_picture_title">
+
+                    <ImageView
+                        android:id="@+id/iv_profile_picture"
+                        android:layout_width="64dp"
+                        android:layout_height="64dp"
+                        android:src="@drawable/happy_tomato" />
+                </androidx.cardview.widget.CardView>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_email"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:background="@drawable/profile_border"
-                app:cardCornerRadius="32dp"
-                app:cardElevation="0dp"
+                android:layout_marginHorizontal="24dp"
+                android:layout_marginTop="24dp"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tv_profile_picture_title">
+                app:layout_constraintTop_toBottomOf="@id/cl_profile_picture">
+                <TextView
+                    android:id="@+id/tv_email_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/p_medium"
+                    android:text="이메일"
+                    android:textColor="@color/gray_700"
+                    android:textSize="@dimen/text_size_body4"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+                <TextView
+                    android:id="@+id/tv_email"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/p_medium"
+                    android:text="banwol@google.com"
+                    android:textColor="@color/gray_400"
+                    android:layout_marginLeft="4dp"
+                    android:paddingVertical="16dp"
+                    android:textSize="@dimen/text_size_body4"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_email_title" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="24dp"
+                android:layout_marginTop="24dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/cl_email">
+                <TextView
+                    android:id="@+id/tv_name_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/p_medium"
+                    android:text="이름"
+                    android:textColor="@color/gray_700"
+                    android:textSize="@dimen/text_size_body4"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+                <TextView
+                    android:id="@+id/tv_name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/p_medium"
+                    android:text="방울즈"
+                    android:textColor="@color/gray_400"
+                    android:layout_marginLeft="4dp"
+                    android:paddingVertical="16dp"
+                    android:textSize="@dimen/text_size_body4"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_name_title" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_nickname"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="24dp"
+                android:layout_marginTop="24dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/cl_name">
+                <TextView
+                    android:id="@+id/tv_nickname_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/p_medium"
+                    android:text="닉네임"
+                    android:textColor="@color/gray_700"
+                    android:textSize="@dimen/text_size_body4"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+                <TextView
+                    android:id="@+id/tv_nickname"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/p_medium"
+                    android:text="방울이"
+                    android:textColor="@color/gray_400"
+                    android:layout_marginLeft="4dp"
+                    android:paddingVertical="16dp"
+                    android:textSize="@dimen/text_size_body4"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_nickname_title" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_password"
+                android:layout_width="match_parent"
+                android:visibility="gone"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="24dp"
+                android:layout_marginTop="24dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/cl_nickname">
+                <TextView
+                    android:id="@+id/tv_password_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/p_medium"
+                    android:text="패스워드"
+                    android:textColor="@color/gray_700"
+                    android:textSize="@dimen/text_size_body4"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/textInputLayoutPassword"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    app:boxBackgroundColor="@null"
+                    app:boxBackgroundMode="filled"
+                    app:errorIconDrawable="@null"
+                    app:errorTextColor="@color/secondary"
+                    app:hintTextColor="@color/gray_400"
+                    app:layout_constraintTop_toBottomOf="@id/tv_password_title"
+                    app:passwordToggleEnabled="true">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editTextPassword"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@null"
+                        android:hint="8~12자, 영문대소문자, 숫자, 특수문자 포함"
+                        android:inputType="textPassword"
+                        android:paddingStart="4dp"
+                        android:imeOptions="actionNext"
+                        android:textColor="@color/gray_700"
+                        android:textColorHint="@color/gray_400"
+                        android:textSize="@dimen/text_size_body4"
+                        tools:ignore="SpeakableTextPresentCheck,TouchTargetSizeCheck" />
+                </com.google.android.material.textfield.TextInputLayout>
+
                 <ImageView
-                    android:id="@+id/iv_profile_picture"
-                    android:layout_width="64dp"
-                    android:layout_height="64dp"
-                    android:src="@drawable/happy_tomato" />
-            </androidx.cardview.widget.CardView>
+                    android:id="@+id/icErrorPassword"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="-20dp"
+                    android:src="@drawable/error_circle_outline"
+                    android:visibility="gone"
+                    app:layout_constraintStart_toStartOf="@id/textInputLayoutPassword"
+                    app:layout_constraintTop_toBottomOf="@id/textInputLayoutPassword"
+                    app:tint="@color/secondary" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_check_password"
+                android:layout_width="match_parent"
+                android:layout_marginHorizontal="24dp"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                android:layout_marginTop="24dp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/cl_password">
+                <TextView
+                    android:id="@+id/tv_check_password_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/p_medium"
+                    android:text="패스워드 확인"
+                    android:textColor="@color/gray_700"
+                    android:textSize="@dimen/text_size_body4"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/textInputLayoutConfirmPassword"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    app:boxBackgroundColor="@null"
+                    app:boxBackgroundMode="filled"
+                    app:errorEnabled="true"
+                    app:errorIconDrawable="@null"
+                    app:errorTextColor="@color/secondary"
+                    app:hintTextColor="@color/hintColor"
+                    app:layout_constraintTop_toBottomOf="@id/tv_check_password_title"
+                    app:passwordToggleEnabled="true">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editTextConfirmPassword"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="@null"
+                        android:hint=" 패스워드를 확인해주세요"
+                        android:inputType="textPassword"
+                        android:paddingStart="4dp"
+                        android:imeOptions="actionDone"
+                        android:textColor="@color/gray_700"
+                        android:textColorHint="@color/gray_400"
+                        android:textSize="@dimen/text_size_body4"
+                        tools:ignore="SpeakableTextPresentCheck,TouchTargetSizeCheck" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <ImageView
+                    android:id="@+id/icErrorConfirmPassword"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="-20dp"
+                    android:src="@drawable/error_circle_outline"
+                    android:visibility="gone"
+                    app:layout_constraintStart_toStartOf="@id/textInputLayoutConfirmPassword"
+                    app:layout_constraintTop_toBottomOf="@id/textInputLayoutConfirmPassword"
+                    app:tint="@color/secondary" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+            <android.widget.Button
+                android:id="@+id/btn_edit_password_after"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="22dp"
+                android:layout_marginTop="45dp"
+                android:layout_marginBottom="24dp"
+                android:visibility="gone"
+                android:background="@drawable/long_normal_btn"
+                android:fontFamily="@font/pretendard_semibold"
+                android:stateListAnimator="@null"
+                android:text="비밀번호 수정하기"
+                android:textColor="@color/gray_0"
+                android:backgroundTint="@color/primary_300"
+                android:textSize="@dimen/text_size_body4"
+                app:layout_constraintTop_toBottomOf="@id/cl_check_password"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/cl_email"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cl_profile_picture">
-            <TextView
-                android:id="@+id/tv_email_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/p_medium"
-                android:text="이메일"
-                android:textColor="@color/gray_700"
-                android:textSize="@dimen/text_size_body4"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-            <TextView
-                android:id="@+id/tv_email"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/p_medium"
-                android:text="banwol@google.com"
-                android:textColor="@color/gray_400"
-                android:layout_marginLeft="4dp"
-                android:paddingVertical="16dp"
-                android:textSize="@dimen/text_size_body4"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tv_email_title" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/cl_name"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cl_email">
-            <TextView
-                android:id="@+id/tv_name_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/p_medium"
-                android:text="이름"
-                android:textColor="@color/gray_700"
-                android:textSize="@dimen/text_size_body4"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-            <TextView
-                android:id="@+id/tv_name"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/p_medium"
-                android:text="방울즈"
-                android:textColor="@color/gray_400"
-                android:layout_marginLeft="4dp"
-                android:paddingVertical="16dp"
-                android:textSize="@dimen/text_size_body4"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tv_name_title" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/cl_nickname"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="24dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/cl_name">
-            <TextView
-                android:id="@+id/tv_nickname_title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/p_medium"
-                android:text="닉네임"
-                android:textColor="@color/gray_700"
-                android:textSize="@dimen/text_size_body4"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-            <TextView
-                android:id="@+id/tv_nickname"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/p_medium"
-                android:text="방울이"
-                android:textColor="@color/gray_400"
-                android:layout_marginLeft="4dp"
-                android:paddingVertical="16dp"
-                android:textSize="@dimen/text_size_body4"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/tv_nickname_title" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </ScrollView>
 
 
     <android.widget.Button
-        android:id="@+id/btn_save"
+        android:id="@+id/btn_edit_password_before"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="22dp"
         android:layout_marginBottom="24dp"
         android:background="@drawable/long_normal_btn"
         android:fontFamily="@font/pretendard_semibold"
+        android:visibility="visible"
         android:stateListAnimator="@null"
         android:text="비밀번호 수정하기"
         android:textColor="@color/gray_600"
@@ -199,6 +353,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
+
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
# 개요
###### PR에 관한 개략적인 설명을 써주세요

개인 정보 수정화면 작성

# 수정사항
###### 작업 내용을 써주세요

개인 정보 수정화면 layout 작성
mypage fragment에서 이동되게 연결
닉네임, 이메일 정보 받아 수정화면에서 띄움
비밀번호 수정하기 버튼 클릭시 비밀번호 입력란 띄우는 interaction 추가

# 유의사항
###### 리뷰 시 참고할 내용을 써주세요

앞으로 보완해야할 사항입니다 ------------------------

mypage에서 이름 정보도 같이 받아서 넘겨야할것같은데 mypage api에서 이름은 받아오지 않는것 같은데 이름도 같이 받아올수있게 수정할 필요있음

비밀번호 수정할때 비밀번호 유효성 검사 + 유효성에따른 버튼 상태 조정

비밀번호 수정 api 필요

후에 프로필 이미지 관련 인터렉션 추가

프로필 수정 api 필요 (아마 이메일 변경은 안되고 이름, 닉네임 정도 수정하는 걸로)

이름 닉네임 수정할수있게 textinput 이용한 상호작용 필요 (지금은 textview로 구현되있음)

버튼 보니깐 비밀번호 수정버튼만 있던데 이름이나 닉네임 수정할때는 각 수정 페이지를 만들어 하나씩 수정하게 하는게 나을것같기도함 (프로필수정 api도 그러면 닉네임 수정 api, 이름 수정 api 이런식으로 따로 만들면 될듯)

비밀번호 수정 전에 보통 현재 비밀번호 입력해서 보안검사하던데 우리도 이런식으로 해야할듯요 